### PR TITLE
Remove notifications before duel

### DIFF
--- a/QuizFight/app/src/main/java/rogueone/quizfight/DuelActivity.java
+++ b/QuizFight/app/src/main/java/rogueone/quizfight/DuelActivity.java
@@ -2,6 +2,8 @@ package rogueone.quizfight;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.Loader;
@@ -118,6 +120,9 @@ public class DuelActivity extends SavedGamesActivity {
 
         count = 0; score = 0;
         answers = new boolean[5];
+
+        NotificationManager notificationManager = (NotificationManager) getApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.cancelAll();
     }
 
     /**


### PR DESCRIPTION
Remove notifications before a new round so that there's always a unique entry point for answering