### PR TITLE
Solve random duel's issue

### DIFF
--- a/QuizFight/app/src/main/java/rogueone/quizfight/rest/pojo/RESTDuel.java
+++ b/QuizFight/app/src/main/java/rogueone/quizfight/rest/pojo/RESTDuel.java
@@ -15,7 +15,7 @@ public class RESTDuel {
     private String[] topics;
 
     public RESTDuel(@NonNull String user1, @NonNull String[] topics) {
-        new RESTDuel(user1, null, topics);
+        this(user1, null, topics);
     }
 
     public RESTDuel(@NonNull String user1, String user2, @NonNull String[] topics) {


### PR DESCRIPTION
Solve issue when creating a duel with a random player. There was a stupid `new RESTDuel` instead of `this` in a constructor. 

Quoting GOT's Septa Unella, "Shame Shame Shame" on me.